### PR TITLE
Add wrapper to MQTT Client so we don't need global variables.

### DIFF
--- a/lib/MQTTClientWrapper/MQTTClientWrapper.h
+++ b/lib/MQTTClientWrapper/MQTTClientWrapper.h
@@ -1,0 +1,67 @@
+#ifndef MQTTCLIENTWRAPPER_H
+#define MQTTCLIENTWRAPPER_H
+
+#include <PubSubClient.h>
+#include <WiFiClient.h>
+
+
+class MQTTClientWrapper : public PubSubClient
+{
+    public:
+        MQTTClientWrapper(WiFiClient &wifi) : PubSubClient(wifi)
+        {}
+
+        PubSubClient& setServer(String serverAddress, int port)
+        {
+            _serverAddress = serverAddress;
+            return PubSubClient::setServer(_serverAddress.c_str(), port);
+        }
+
+        bool connect(const String id) {
+            _id = id;
+            return PubSubClient::connect(_id.c_str());
+        }
+
+        bool connect(const String id, const String user, const String pass) {
+            _id = id;
+            _user = user;
+            _pass = pass;
+            return PubSubClient::connect(_id.c_str(), _user.c_str(), _pass.c_str());
+        }
+
+        bool connect(const String id, const String willTopic, uint8_t willQos, boolean willRetain, const String willMessage) {
+            _id = id;
+            _willTopic = willTopic;
+            _willMessage = willMessage;
+            return PubSubClient::connect(_id.c_str(), _willTopic.c_str(), willQos, willRetain, _willMessage.c_str());
+        }
+
+        bool connect(const String id, const String user, const String pass, const String willTopic, uint8_t willQos, boolean willRetain, const String willMessage) {
+            _id = id;
+            _user = user;
+            _pass = pass;
+            _willTopic = willTopic;
+            _willMessage = willMessage;
+            return PubSubClient::connect(_id.c_str(), _user.c_str(), _pass.c_str(), _willTopic.c_str(), willQos, willRetain, _willMessage.c_str());
+        }
+
+        bool connect(const char *id, const char *user, const char *pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, boolean cleanSession) {
+            _id = id;
+            _user = user;
+            _pass = pass;
+            _willTopic = willTopic;
+            _willMessage = willMessage;
+            return PubSubClient::connect(_id.c_str(), _user.c_str(), _pass.c_str(), _willTopic.c_str(), willQos, willRetain, _willMessage.c_str(), cleanSession);
+         }
+
+    private:
+        String _serverAddress;
+        String _id;
+        String _user;
+        String _pass;
+        String _willTopic;
+        String _willMessage;
+
+};
+
+#endif // MQTTCLIENTWRAPPER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include "SpaInterface.h"
 #include "SpaUtils.h"
 #include "HAAutoDiscovery.h"
+#include "MQTTClientWrapper.h"
 
 //define stringify function
 #define xstr(a) str(a)
@@ -33,7 +34,7 @@ Config config;
 #endif
 
 WiFiClient wifi;
-PubSubClient mqttClient(wifi);
+MQTTClientWrapper mqttClient(wifi);
 
 WebUI ui(&si, &config);
 
@@ -51,9 +52,6 @@ String mqttBase = "";
 String mqttStatusTopic = "";
 String mqttSet = "";
 String mqttAvailability = "";
-String mqttServer = "";
-String mqttUsername = "";
-String mqttPassword = "";
 
 String spaSerialNumber = "";
 
@@ -121,21 +119,10 @@ void startWifiManagerCallback() {
 
 void configChangeCallbackString(const char* name, String value) {
   debugD("%s: %s", name, value);
-  if (strcmp(name, "MqttServer") == 0) {
-    mqttServer = value;
-    updateMqtt = true;
-  }
-  else if (strcmp(name, "MqttPort") == 0) {
-    updateMqtt = true;
-  }
-  else if (strcmp(name, "MqttUsername") == 0) {
-    mqttUsername = value;
-    updateMqtt = true;
-  }
-  else if (strcmp(name, "MqttPassword") == 0) {
-    mqttPassword = value;
-    updateMqtt = true;
-  }
+  if (strcmp(name, "MqttServer") == 0) updateMqtt = true;
+  else if (strcmp(name, "MqttPort") == 0) updateMqtt = true;
+  else if (strcmp(name, "MqttUsername") == 0) updateMqtt = true;
+  else if (strcmp(name, "MqttPassword") == 0) updateMqtt = true;
   else if (strcmp(name, "SpaName") == 0) { } //TODO - Changing the SpaName currently requires the user to:
                                   // delete the entities in MQTT then reboot the ESP
 }
@@ -594,10 +581,7 @@ void setup() {
     //I'm not sure if we need a reboot here - probably not
   }
 
-  mqttServer = config.MqttServer.getValue();
-  mqttUsername = config.MqttUsername.getValue();
-  mqttPassword = config.MqttPassword.getValue();
-  mqttClient.setServer(mqttServer.c_str(), config.MqttPort.getValue());
+  mqttClient.setServer(config.MqttServer.getValue(), config.MqttPort.getValue());
   mqttClient.setCallback(mqttCallback);
   mqttClient.setBufferSize(2048);
 
@@ -627,9 +611,7 @@ void loop() {
   if (updateMqtt) {
     debugD("Changing MQTT settings...");
     mqttClient.disconnect();
-    mqttClient.setServer(mqttServer.c_str(), config.MqttPort.getValue());
-    mqttClient.setCallback(mqttCallback);
-    mqttClient.setBufferSize(2048);
+    mqttClient.setServer(config.MqttServer.getValue(), config.MqttPort.getValue());
     updateMqtt = false;
   }
 
@@ -667,11 +649,11 @@ void loop() {
           if (now - mqttLastConnect > 1000) {
             blinker.setState(STATE_MQTT_NOT_CONNECTED);
             
-            debugW("MQTT not connected, attempting connection to %s:%i", mqttServer.c_str(), config.MqttPort.getValue());
+            debugW("MQTT not connected, attempting connection to %s:%i", config.MqttServer.getValue(), config.MqttPort.getValue());
             mqttLastConnect = now;
 
 
-            if (mqttClient.connect("sn_esp32", mqttUsername.c_str(), mqttPassword.c_str(), mqttAvailability.c_str(),2,true,"offline")) {
+            if (mqttClient.connect("sn_esp32", config.MqttUsername.getValue(), config.MqttPassword.getValue(), mqttAvailability.c_str(),2,true,"offline")) {
               debugI("MQTT connected");
     
               String subTopic = mqttBase+"set/#";


### PR DESCRIPTION
This change removes the global variables and uses a wrapper class for the MQTT client. Which I think is a cleaner solution.