### PR TITLE
Reenable serial debugging by default

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -49,4 +49,3 @@ build_flags =
   -D TX_PIN=15
   -D EN_PIN=0
   -D SPA_SERIAL=Serial2
-  ; -D ENABLE_SERIAL=1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -561,11 +561,9 @@ void setup() {
     pinMode(EN_PIN, INPUT_PULLUP);
   #endif
 
-  #if defined(ENABLE_SERIAL)
-    Serial.begin(115200);
-    Serial.setDebugOutput(true);
-    Debug.setSerialEnabled(true);
-  #endif
+  Serial.begin(115200);
+  Serial.setDebugOutput(true);
+  Debug.setSerialEnabled(true);
 
   blinker.setState(STATE_NONE); // start with all LEDs off
   blinker.start();


### PR DESCRIPTION
Serial debugging was removed in error in commit c616c82, then reinstated in b0e02013712801a5732a75f4b1dda98468f12ff0

But when it was re-enabled, it was not on like default like before. This PR reverts to the original state.