### PR TITLE
Add support for multi speed pumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-Lots of little updates:
-* WebUI added additional spa info
-* Support for Multi LEDs PCBs
-* Added one click button to WebUI, to set the spa date/time.
-* MQTT client fixes
+**Added support for multi-speed pumps**
+
+**Breaking change**
+* This changes the pumps to type fan, but does not delete the old pump switches. You will need to manually delete them with MQTT explorer or disable them in HA.
+* This will break any pump automations you have.

--- a/lib/HAAutoDiscovery/HAAutoDiscovery.h
+++ b/lib/HAAutoDiscovery/HAAutoDiscovery.h
@@ -52,9 +52,7 @@ void generateSelectAdJSON(String& output, const AutoDiscoveryInformationTemplate
    serializeJson(json, output);
 }
 
-
-void generateFanAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic);
-
+void generateFanAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, int min, int max, const String* modes, const size_t modesSize=0);
 
 template <typename T, size_t N>
 void generateLightAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, const std::array<T, N>& colorModes) {
@@ -95,7 +93,6 @@ void generateLightAdJSON(String& output, const AutoDiscoveryInformationTemplate&
 
    serializeJson(json, output);
 }
-
 
 void generateClimateAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic);
 

--- a/lib/SpaInterface/SpaInterface.h
+++ b/lib/SpaInterface/SpaInterface.h
@@ -229,15 +229,39 @@ class SpaInterface : public SpaProperties {
 
 
 // Define the function pointer type for getPumpInstallState functions
-typedef String (SpaInterface::*GetPumpStateFunction)();
+typedef String (SpaInterface::*GetPumpStateInstallFunction)();
 
 // Declare the array of function pointers for each pump's install state as static
-static GetPumpStateFunction pumpStateFunctions[] = {
+static GetPumpStateInstallFunction pumpInstallStateFunctions[] = {
   &SpaInterface::getPump1InstallState,
   &SpaInterface::getPump2InstallState,
   &SpaInterface::getPump3InstallState,
   &SpaInterface::getPump4InstallState,
   &SpaInterface::getPump5InstallState
+};
+
+// Define the function pointer type for getPumpState functions
+typedef int (SpaInterface::*GetPumpStateFunction)();
+
+// Declare the array of function pointers for each pump's state as static
+static GetPumpStateFunction pumpStateFunctions[] = {
+  &SpaInterface::getRB_TP_Pump1,
+  &SpaInterface::getRB_TP_Pump2,
+  &SpaInterface::getRB_TP_Pump3,
+  &SpaInterface::getRB_TP_Pump4,
+  &SpaInterface::getRB_TP_Pump5
+};
+
+// Define the function pointer type for getPumpState functions
+typedef bool (SpaInterface::*SetPumpFunction)(int);
+
+// Declare the array of function pointers for each pump's state as static
+static SetPumpFunction setPumpFunctions[] = {
+  &SpaInterface::setRB_TP_Pump1,
+  &SpaInterface::setRB_TP_Pump2,
+  &SpaInterface::setRB_TP_Pump3,
+  &SpaInterface::setRB_TP_Pump4,
+  &SpaInterface::setRB_TP_Pump5
 };
 
 #endif

--- a/lib/SpaInterface/SpaProperties.h
+++ b/lib/SpaInterface/SpaProperties.h
@@ -1131,9 +1131,11 @@ public:
 
     int getRB_TP_Pump5() { return RB_TP_Pump5.getValue(); }
     void setRB_TP_Pump5Callback(void (*callback)(int)) { RB_TP_Pump5.setCallback(callback); }
+    const std::array<String, 2> autoPumpOptions = {"Manual", "Auto"};
 
     int getRB_TP_Blower() { return RB_TP_Blower.getValue(); }
     void setRB_TP_BlowerCallback(void (*callback)(int)) { RB_TP_Blower.setCallback(callback); }
+    const std::array <String, 2> blowerStrings = {"Variable", "Ramp"};
 
     int getRB_TP_Light() { return RB_TP_Light.getValue(); }
     void setRB_TP_LightCallback(void (*callback)(int)) { RB_TP_Light.setCallback(callback); }

--- a/lib/SpaUtils/SpaUtils.cpp
+++ b/lib/SpaUtils/SpaUtils.cpp
@@ -44,28 +44,24 @@ int convertToInteger(String &timeStr) {
   return data;
 }
 
-bool getPumpModes(SpaInterface &si, int pumpNumber, JsonObject pumps) {
+bool getPumpModesJson(SpaInterface &si, int pumpNumber, JsonObject pumps) {
   // Validate the pump number
   if (pumpNumber < 1 || pumpNumber > 5) {
     return false;
   }
 
   // Retrieve the pump install state dynamically
-  String pumpState = (si.*(pumpStateFunctions[pumpNumber - 1]))();
-
-  // Split pumpState by "-"
-  int firstDash = pumpState.indexOf("-");
-  int secondDash = pumpState.indexOf("-", firstDash + 1);
+  String pumpInstallState = (si.*(pumpInstallStateFunctions[pumpNumber - 1]))();
 
   char pumpKey[6] = "pump";  // Start with "pump"
   pumpKey[4] = '0' + pumpNumber;  // Append the pump number as a character
   pumpKey[5] = '\0';  // Null-terminate the string
 
-  // Convert installed to a boolean (true for "1", false for "0")
-  pumps[pumpKey]["installed"] = (pumpState.substring(0, firstDash) == "1");
-  pumps[pumpKey]["speedType"] = pumpState.substring(firstDash + 1, secondDash);
+  pumps[pumpKey]["installed"] = getPumpInstalledState(pumpInstallState);
+  String speedType = getPumpSpeedType(pumpInstallState);
+  pumps[pumpKey]["speedType"] = speedType;
 
-  String possibleStates = pumpState.substring(secondDash + 1);
+  String possibleStates = getPumpPossibleStates(pumpInstallState);
   // Convert possibleStates into words and store them in a JSON array
   for (uint i = 0; i < possibleStates.length(); i++) {
     char stateChar = possibleStates.charAt(i);
@@ -73,12 +69,61 @@ bool getPumpModes(SpaInterface &si, int pumpNumber, JsonObject pumps) {
       pumps[pumpKey]["possibleStates"].add("OFF");
     } else if (stateChar == '1') {
       pumps[pumpKey]["possibleStates"].add("ON");
+    } else if (stateChar == '2') {
+      pumps[pumpKey]["possibleStates"].add("LOW");
+    } else if (stateChar == '3') {
+      pumps[pumpKey]["possibleStates"].add("HIGH");
     } else if (stateChar == '4') {
       pumps[pumpKey]["possibleStates"].add("AUTO");
     }
   }
 
+  int pumpState = (si.*(pumpStateFunctions[pumpNumber - 1]))();
+  if (pumpInstallState.endsWith("4") && possibleStates.length() > 1) {
+    if (pumpState == 4) pumps[pumpKey]["mode"] = "Auto";
+    else pumps[pumpKey]["mode"] = "Manual";
+  }
+  pumps[pumpKey]["state"] = pumpState==0?"OFF":"ON";
+  if (pumpState == 4) pumpState = 2;
+  pumps[pumpKey]["speed"] = pumpState;
+
   return true;
+}
+
+bool getPumpInstalledState(String pumpInstallState) {
+  return pumpInstallState.startsWith("1");
+}
+
+String getPumpSpeedType(String pumpInstallState) {
+  int firstDash = pumpInstallState.indexOf("-");
+  int secondDash = pumpInstallState.lastIndexOf("-");
+  return pumpInstallState.substring(firstDash + 1, secondDash);
+}
+
+String getPumpPossibleStates(String pumpInstallState) {
+  int secondDash = pumpInstallState.lastIndexOf("-");
+  return pumpInstallState.substring(secondDash + 1);
+}
+
+int getPumpSpeedMax(String pumpInstallState) {
+  String possibleStates = getPumpPossibleStates(pumpInstallState);
+  uint max = 0;
+  for (uint i = 0; i < possibleStates.length(); i++) {
+    int pumpMode = possibleStates.charAt(i)  - '0';
+    if (pumpMode > 0 && pumpMode < 4 && pumpMode > max) max = pumpMode;
+  }
+  return max;
+}
+
+int getPumpSpeedMin(String pumpInstallState) {
+  String possibleStates = getPumpPossibleStates(pumpInstallState);
+  uint min = UINT_MAX;
+  for (uint i = 0; i < possibleStates.length(); i++) {
+    int pumpMode = possibleStates.charAt(i)  - '0';
+    if (pumpMode > 0 && pumpMode < 4 && pumpMode < min) min = pumpMode;
+  }
+  if (min == UINT_MAX) min = 0;
+  return min;
 }
 
 bool generateStatusJson(SpaInterface &si, MQTTClientWrapper &mqttClient, String &output, bool prettyJson) {
@@ -111,16 +156,10 @@ bool generateStatusJson(SpaInterface &si, MQTTClientWrapper &mqttClient, String 
   JsonObject pumps = json["pumps"].to<JsonObject>();
   // Add pump data by calling the function for each pump
   for (int i = 1; i <= 5; i++) {
-    if (!getPumpModes(si, i, pumps)) {
+    if (!getPumpModesJson(si, i, pumps)) {
       debugD("Invalid pump number: %i", i);
     }
   }
-
-  json["pumps"]["pump1"]["state"] = si.getRB_TP_Pump1()==0? "OFF" : "ON"; // we're ignoring auto here
-  json["pumps"]["pump2"]["state"] = si.getRB_TP_Pump2()==0? "OFF" : "ON"; // we're ignoring auto here
-  json["pumps"]["pump3"]["state"] = si.getRB_TP_Pump3()==0? "OFF" : "ON"; // we're ignoring auto here
-  json["pumps"]["pump4"]["state"] = si.getRB_TP_Pump4()==0? "OFF" : "ON"; // we're ignoring auto here
-  json["pumps"]["pump5"]["state"] = si.getRB_TP_Pump5()==0? "OFF" : "ON"; // we're ignoring auto here
 
   String y=String(year(si.getSpaTime()));
   String m=String(month(si.getSpaTime()));

--- a/lib/SpaUtils/SpaUtils.h
+++ b/lib/SpaUtils/SpaUtils.h
@@ -15,7 +15,14 @@ extern RemoteDebug Debug;
 
 String convertToTime(int data);
 int convertToInteger(String &timeStr);
-bool getPumpModes(SpaInterface &si, int pumpNumber, JsonObject pumps);
+bool getPumpModesJson(SpaInterface &si, int pumpNumber, JsonObject pumps);
+
+bool getPumpInstalledState(String pumpState);
+String getPumpSpeedType(String pumpState);
+String getPumpPossibleStates(String pumpState);
+int getPumpSpeedMax(String pumpState);
+int getPumpSpeedMin(String pumpState);
+
 bool generateStatusJson(SpaInterface &si, MQTTClientWrapper &mqttClient, String &output, bool prettyJson=false);
 
 #endif // SPAUTILS_H


### PR DESCRIPTION
Breaking change. This changes the pumps to type fan, but does not delete the old pump switches. You will need to manually delete them with MQTT explorer or disable them in HA. This will break any pump automations you have.

There's quite a bit going on here. I'm happy to explain or add more comments to the code. Summary of changes:
* Modified generateFanAdJSON so it can be leveraged by the blower and multi-speed pumps.
* I'm using a pointer to pass the options in because the options change at run time. I wonder if we should change select and light to use the same approach?
* Added additional json value for pump mode (manual or auto) - only displayed for pumps with auto and more than one other speed setting. I.e. existing single speed auto pumps are still ignored as they only have one speed (4 - auto).
* Added supporting functions to decode pump install state codes. As we need to do this often.
* Pump auto discovery moved to a loop to avoid code repetition.
* MQTT Callback logic for pumps updated to handle all pumps to avoid code repetition.

Note: Testing identified sending 2 set the multi-speed pumps to high. But then the spa reported pump state 3. Likewise sending 3 to the spa set the pumps to low, and then the spa reported pump state 2. This doesn't feel right, so maybe we're missing something, but it appears to work correctly.