### PR TITLE
Added mDNS support

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include <WiFiClient.h>
 #include <RemoteDebug.h>
 #include <WiFiManager.h>
+#include <ESPmDNS.h>
 
 #include "MultiBlinker.h"
 
@@ -554,15 +555,7 @@ void setup() {
   blinker.setState(STATE_NONE); // start with all LEDs off
   blinker.start();
 
-  delay(200);
-  debugA("Starting... %s", WiFi.getHostname());
-
-  WiFi.mode(WIFI_STA); 
-  WiFi.begin();
-
-  Debug.begin(WiFi.getHostname());
-  Debug.setResetCmdEnabled(true);
-  Debug.showProfiler(true);
+  debugA("Starting ESP...");
 
   debugI("Mounting FS");
 
@@ -575,8 +568,32 @@ void setup() {
   if (!config.readConfigFile()) {
     debugW("Failed to open config.json, starting Wi-Fi Manager");
     startWiFiManager();
-    //I'm not sure if we need a reboot here - probably not
   }
+
+  blinker.setState(STATE_WIFI_NOT_CONNECTED);
+  WiFi.setHostname(config.SpaName.getValue().c_str());
+
+  WiFi.mode(WIFI_STA);
+  WiFi.begin();
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    debugA(".");
+  }
+  debugA("Connected to Wi-Fi");
+
+  blinker.setState(STATE_NONE); // start with all LEDs off
+
+  Debug.begin(WiFi.getHostname());
+  Debug.setResetCmdEnabled(true);
+  Debug.showProfiler(true);
+
+  int totalTry = 5;
+  while (!MDNS.begin(WiFi.getHostname()) && totalTry > 0) {
+    debugW(".");
+    delay(1000);
+    totalTry--;
+  }
+  debugA("mDNS responder started");
 
   mqttClient.setServer(config.MqttServer.getValue(), config.MqttPort.getValue());
   mqttClient.setCallback(mqttCallback);


### PR DESCRIPTION
This enables the eSpa to be accessed via the spa name (defaults to MySpa) instead of needing to know the IP address: myspa.local

The Spa Name is configurable, therefore this change necessitated moving the config read above the Wi-Fi connection in setup(). I don't see any reason not to do this.

I think we should change the default spa name to eSpa to match the new project name. This change will need to be done carefully, as it could result in a breaking change.