### PR TITLE
Firmware updates

### DIFF
--- a/lib/Config/Config.cpp
+++ b/lib/Config/Config.cpp
@@ -31,6 +31,7 @@ bool Config::readConfigFile() {
       if (json["mqtt_password"].is<String>()) MqttPassword.setValue(json["mqtt_password"].as<String>());
       if (json["spa_name"].is<String>()) SpaName.setValue(json["spa_name"].as<String>());
       if (json["update_frequency"].is<int>()) spaPollFrequency.setValue(json["update_frequency"].as<int>());
+      if (json["firmware_update_check_frequency"].is<int>()) firmwareUpdateCheckFrequency.setValue(json["firmware_update_check_frequency"].as<int>());
     } else {
       debugW("Failed to parse config file");
     }
@@ -51,6 +52,7 @@ void Config::writeConfigFile() {
   json["mqtt_password"] = MqttPassword.getValue();
   json["spa_name"] = SpaName.getValue();
   json["update_frequency"] = spaPollFrequency.getValue();
+  json["firmware_update_check_frequency"] = firmwareUpdateCheckFrequency.getValue();
 
   File configFile = LittleFS.open("/config.json", "w");
   if (!configFile) {

--- a/lib/Config/Config.cpp
+++ b/lib/Config/Config.cpp
@@ -30,7 +30,7 @@ bool Config::readConfigFile() {
       if (json["mqtt_username"].is<String>()) MqttUsername.setValue(json["mqtt_username"].as<String>());
       if (json["mqtt_password"].is<String>()) MqttPassword.setValue(json["mqtt_password"].as<String>());
       if (json["spa_name"].is<String>()) SpaName.setValue(json["spa_name"].as<String>());
-      if (json["update_frequency"].is<int>()) UpdateFrequency.setValue(json["update_frequency"].as<int>());
+      if (json["update_frequency"].is<int>()) spaPollFrequency.setValue(json["update_frequency"].as<int>());
     } else {
       debugW("Failed to parse config file");
     }
@@ -50,7 +50,7 @@ void Config::writeConfigFile() {
   json["mqtt_username"] = MqttUsername.getValue();
   json["mqtt_password"] = MqttPassword.getValue();
   json["spa_name"] = SpaName.getValue();
-  json["update_frequency"] = UpdateFrequency.getValue();
+  json["update_frequency"] = spaPollFrequency.getValue();
 
   File configFile = LittleFS.open("/config.json", "w");
   if (!configFile) {

--- a/lib/Config/Config.h
+++ b/lib/Config/Config.h
@@ -69,7 +69,7 @@ public:
     Setting<String> MqttUsername = Setting<String>("MqttUsername");
     Setting<String> MqttPassword = Setting<String>("MqttPassword");
     Setting<String> SpaName = Setting<String>("SpaName", "eSpa");
-    Setting<int> UpdateFrequency = Setting<int>("UpdateFrequency", 60, 10, 300);
+    Setting<int> spaPollFrequency = Setting<int>("spaPollFrequency", 60, 10, 300);
 };
 
 class Config : public ControllerConfig {

--- a/lib/Config/Config.h
+++ b/lib/Config/Config.h
@@ -70,6 +70,14 @@ public:
     Setting<String> MqttPassword = Setting<String>("MqttPassword");
     Setting<String> SpaName = Setting<String>("SpaName", "eSpa");
     Setting<int> spaPollFrequency = Setting<int>("spaPollFrequency", 60, 10, 300);
+    Setting<int> firmwareUpdateCheckFrequency = Setting<int>("firmwareUpdateCheckFrequency", 24, 0, 1000);
+
+    // The following settings aren't saved but are used as in memory storage
+    Setting<String> latestVersion = Setting<String>("latestVersion", "unknown");
+    Setting<int> updateAvailable = Setting<int>("updateAvailable", 0, 0, 1);
+    Setting<String> releaseNotes = Setting<String>("releaseNotes", "unknown");
+    Setting<String> releaseUrl = Setting<String>("releaseUrl", "unknown");
+    Setting<String> firmwareUrl = Setting<String>("firmwareUrl");
 };
 
 class Config : public ControllerConfig {

--- a/lib/HAAutoDiscovery/HAAutoDiscovery.cpp
+++ b/lib/HAAutoDiscovery/HAAutoDiscovery.cpp
@@ -79,6 +79,16 @@ void generateSwitchAdJSON(String& output, const AutoDiscoveryInformationTemplate
    serializeJson(json, output);
 }
 
+void generateUpdateAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic) {
+   JsonDocument json;
+   generateCommonAdJSON(json, config, spa, discoveryTopic, "update");
+
+   json["command_topic"] = spa.commandTopic + "/" + config.propertyId;
+   json["payload_install"] = "update";
+
+   serializeJson(json, output);
+}
+
 void generateFanAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, int min, int max, const String* modes, const size_t modesSize) {
    JsonDocument json;
    generateCommonAdJSON(json, config, spa, discoveryTopic, "fan");

--- a/lib/HAAutoDiscovery/HAAutoDiscovery.h
+++ b/lib/HAAutoDiscovery/HAAutoDiscovery.h
@@ -39,6 +39,7 @@ void generateSensorAdJSON(String& output, const AutoDiscoveryInformationTemplate
 void generateBinarySensorAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic);
 void generateTextAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, String regex="");
 void generateSwitchAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic);
+void generateUpdateAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic);
 
 template <typename T, size_t N>
 void generateSelectAdJSON(String& output, const AutoDiscoveryInformationTemplate& config, const SpaADInformationTemplate& spa, String &discoveryTopic, const std::array<T, N>& options) {

--- a/lib/HttpContent/HttpContent.cpp
+++ b/lib/HttpContent/HttpContent.cpp
@@ -1,0 +1,85 @@
+#include "HttpContent.h"
+
+HttpContent::HttpContent() {}
+
+bool HttpContent::getHttpClient(const String url, HTTPClient& http) {
+    int redirectCount = 0;
+    String currentUrl = url;
+
+    while (redirectCount < MAX_REDIRECTS) {
+        debugD("Requesting URL: %s", currentUrl.c_str());
+        http.begin(currentUrl);
+        int httpCode = http.GET();
+
+        if (httpCode == HTTP_CODE_OK) {
+            debugD("HTTP GET successful for URL: %s", currentUrl.c_str());
+            return true;
+        } else if (httpCode == HTTP_CODE_MOVED_PERMANENTLY || httpCode == HTTP_CODE_FOUND) {
+            String newUrl = http.getLocation();
+            if (newUrl.isEmpty()) {
+                debugE("Redirect response with empty location.");
+                http.end();
+                return false;
+            }
+            currentUrl = newUrl;
+            debugD("Redirecting to: %s", currentUrl.c_str());
+            redirectCount++;
+            http.end();
+        } else {
+            debugE("HTTP GET failed for URL: %s, Code: %d", currentUrl.c_str(), httpCode);
+            http.end();
+            return false;
+        }
+    }
+
+    debugE("Maximum redirects (%d) reached for URL: %s", MAX_REDIRECTS, url.c_str());
+    return false;
+}
+
+bool HttpContent::fetchHttpContent(const String url, String& content) {
+    HTTPClient http;
+    if (getHttpClient(url, http)) {
+        content = http.getString();
+        debugD("Fetched content");
+        debugV("%s", content.c_str());
+        http.end();
+        return true;
+    }
+
+    debugE("Failed to fetch content from URL: %s", url.c_str());
+    return false;
+}
+
+bool HttpContent::updateFirmware(const String firmwareUrl) {
+    HTTPClient http;
+
+    if (getHttpClient(firmwareUrl, http)) {
+        WiFiClient* stream = http.getStreamPtr();
+        size_t contentLength = http.getSize();
+
+        if (!Update.begin(contentLength)) {
+            debugE("Update.begin() failed: Not enough space for update.");
+            http.end();
+            return false;
+        }
+
+        debugD("Writing firmware to flash...");
+        size_t written = Update.writeStream(*stream);
+        if (written == contentLength) {
+            if (Update.end() && Update.isFinished()) {
+                debugD("Success: Firmware update complete.");
+                http.end();
+                return true;
+            } else {
+                debugE("Firmware update failed to complete.");
+            }
+        } else {
+            debugE("Firmware write failed. Written: %zu, Expected: %zu", written, contentLength);
+        }
+        http.end();
+    } else {
+        debugE("Failed to initialize HTTPClient for firmware URL: %s", firmwareUrl.c_str());
+    }
+
+    return false;
+}

--- a/lib/HttpContent/HttpContent.h
+++ b/lib/HttpContent/HttpContent.h
@@ -1,0 +1,42 @@
+#ifndef HTTP_CONTENT_H
+#define HTTP_CONTENT_H
+
+#include <Arduino.h>
+#include <HTTPClient.h>
+#include <Update.h>
+#include <RemoteDebug.h>
+
+extern RemoteDebug Debug;
+
+#define MAX_REDIRECTS 5
+
+class HttpContent {
+private:
+    /**
+     * Attempts to initialize an HTTPClient for the given URL, following redirects if necessary.
+     * @param url The URL to fetch.
+     * @param http A reference to the HTTPClient object.
+     * @return True if the HTTPClient was successfully initialized; false otherwise.
+     */
+    bool getHttpClient(const String url, HTTPClient& http);
+
+public:
+    HttpContent();
+
+    /**
+     * Fetches the content from the specified URL as a String.
+     * @param url The URL to fetch.
+     * @param content A reference to the String where the fetched content will be stored.
+     * @return True if the content was successfully fetched; false otherwise.
+     */
+    bool fetchHttpContent(const String url, String& content);
+
+    /**
+     * Updates the firmware from the given URL.
+     * @param firmwareUrl The URL of the firmware file.
+     * @return True if the firmware update was successful; false otherwise.
+     */
+    bool updateFirmware(const String firmwareUrl);
+};
+
+#endif // HTTP_CONTENT_H

--- a/lib/SpaInterface/SpaInterface.cpp
+++ b/lib/SpaInterface/SpaInterface.cpp
@@ -12,7 +12,7 @@ SpaInterface::SpaInterface() : port(SPA_SERIAL) {
 SpaInterface::~SpaInterface() {}
 
 
-void SpaInterface::setUpdateFrequency(int updateFrequency) {
+void SpaInterface::setPollFrequency(int updateFrequency) {
     _updateFrequency = updateFrequency;
 }
 

--- a/lib/SpaInterface/SpaInterface.h
+++ b/lib/SpaInterface/SpaInterface.h
@@ -114,7 +114,7 @@ class SpaInterface : public SpaProperties {
 
         /// @brief configure how often the spa is polled in seconds.
         /// @param updateFrequency
-        void setUpdateFrequency(int updateFrequency);
+        void setPollFrequency(int updateFrequency);
 
         /// @brief Complete RF command response in a single string
         Property<String> statusResponse;

--- a/lib/SpaUtils/SpaUtils.cpp
+++ b/lib/SpaUtils/SpaUtils.cpp
@@ -146,6 +146,9 @@ bool generateStatusJson(SpaInterface &si, MQTTClientWrapper &mqttClient, Config 
   json["status"]["state"] = si.getStatus();
   json["status"]["spaMode"] = si.getMode();
   json["status"]["controller"] = si.getModel();
+  String firmware = si.getSVER().substring(3);
+  firmware.replace(' ', '.');
+  json["status"]["firmware"] = firmware;
   json["status"]["serial"] = si.getSerialNo1() + "-" + si.getSerialNo2();
   json["status"]["siInitialised"] = si.isInitialised()?"true":"false";
   json["status"]["mqtt"] = mqttClient.connected()?"connected":"disconnected";

--- a/lib/SpaUtils/SpaUtils.cpp
+++ b/lib/SpaUtils/SpaUtils.cpp
@@ -282,7 +282,7 @@ int compareVersions(const int current[3], const int latest[3]) {
 void firmwareCheckUpdates(Config &config) {
   HttpContent httpContent;
   String content;
-  if (httpContent.fetchHttpContent("https://api.github.com/repos/wayne-love/ESPySpa/releases/latest", content)) {
+  if (httpContent.fetchHttpContent(RELEASES_URL, content)) {
     JsonDocument doc;
     deserializeJson(doc, content);
     String latestRelease = doc["tag_name"].as<String>();

--- a/lib/SpaUtils/SpaUtils.h
+++ b/lib/SpaUtils/SpaUtils.h
@@ -18,6 +18,8 @@ extern RemoteDebug Debug;
 #define xstr(a) str(a)
 #define str(a) #a
 
+#define RELEASES_URL "https://api.github.com/repos/wayne-love/ESPySpa/releases/latest"
+
 String convertToTime(int data);
 int convertToInteger(String &timeStr);
 bool getPumpModesJson(SpaInterface &si, int pumpNumber, JsonObject pumps);

--- a/lib/SpaUtils/SpaUtils.h
+++ b/lib/SpaUtils/SpaUtils.h
@@ -10,8 +10,13 @@
 #include "Config.h"
 #include <PubSubClient.h>
 #include "MQTTClientWrapper.h"
+#include "HttpContent.h"
 
 extern RemoteDebug Debug;
+
+//define stringify function
+#define xstr(a) str(a)
+#define str(a) #a
 
 String convertToTime(int data);
 int convertToInteger(String &timeStr);
@@ -23,6 +28,11 @@ String getPumpPossibleStates(String pumpState);
 int getPumpSpeedMax(String pumpState);
 int getPumpSpeedMin(String pumpState);
 
-bool generateStatusJson(SpaInterface &si, MQTTClientWrapper &mqttClient, String &output, bool prettyJson=false);
+bool generateStatusJson(SpaInterface &si, MQTTClientWrapper &mqttClient, Config &config, String &output, bool prettyJson=false);
+
+String fetchLatestVersion(const String& url);
+bool parseVersion(const String version, int parsedVersion[3]);
+int compareVersions(const int current[3], const int latest[3]);
+void firmwareCheckUpdates(Config &config);
 
 #endif // SPAUTILS_H

--- a/lib/WebUI/WebUI.cpp
+++ b/lib/WebUI/WebUI.cpp
@@ -105,7 +105,7 @@ void WebUI::begin() {
         if (server->hasArg("mqttPort")) _config->MqttPort.setValue(server->arg("mqttPort").toInt());
         if (server->hasArg("mqttUsername")) _config->MqttUsername.setValue(server->arg("mqttUsername"));
         if (server->hasArg("mqttPassword")) _config->MqttPassword.setValue(server->arg("mqttPassword"));
-        if (server->hasArg("updateFrequency")) _config->UpdateFrequency.setValue(server->arg("updateFrequency").toInt());
+        if (server->hasArg("spaPollFrequency")) _config->spaPollFrequency.setValue(server->arg("spaPollFrequency").toInt());
         _config->writeConfigFile();
         server->sendHeader("Connection", "close");
         server->send(200, "text/plain", "Updated");
@@ -119,7 +119,7 @@ void WebUI::begin() {
         configJson += "\"mqttPort\":\"" + String(_config->MqttPort.getValue()) + "\",";
         configJson += "\"mqttUsername\":\"" + _config->MqttUsername.getValue() + "\",";
         configJson += "\"mqttPassword\":\"" + _config->MqttPassword.getValue() + "\",";
-        configJson += "\"updateFrequency\":" + String(_config->UpdateFrequency.getValue());
+        configJson += "\"spaPollFrequency\":" + String(_config->spaPollFrequency.getValue());
         configJson += "}";
         server->send(200, "application/json", configJson);
     });

--- a/lib/WebUI/WebUI.h
+++ b/lib/WebUI/WebUI.h
@@ -232,7 +232,7 @@ R"(<!DOCTYPE html>
 <tr><td>MQTT Port:</td><td><input type='number' name='mqttPort' id='mqttPort'></td></tr>
 <tr><td>MQTT Username:</td><td><input type='text' name='mqttUsername' id='mqttUsername'></td></tr>
 <tr><td>MQTT Password:</td><td><input type='text' name='mqttPassword' id='mqttPassword'></td></tr>
-<tr><td>Poll Frequency (seconds):</td><td><input type='number' name='updateFrequency' id='updateFrequency' step="1" min="10" max="300"></td></tr>
+<tr><td>Poll Frequency (seconds):</td><td><input type='number' name='spaPollFrequency' id='spaPollFrequency' step="1" min="10" max="300"></td></tr>
 </table>
 <input type='submit' value='Save'>
 </form>
@@ -248,7 +248,7 @@ function loadConfig() {
       document.getElementById('mqttPort').value = data.mqttPort;
       document.getElementById('mqttUsername').value = data.mqttUsername;
       document.getElementById('mqttPassword').value = data.mqttPassword;
-      document.getElementById('updateFrequency').value = data.updateFrequency;
+      document.getElementById('spaPollFrequency').value = data.spaPollFrequency;
     })
   .catch(error => console.error('Error loading config:', error));
 }

--- a/lib/WebUI/WebUI.h
+++ b/lib/WebUI/WebUI.h
@@ -11,10 +11,6 @@
 #include "Config.h"
 #include "MQTTClientWrapper.h"
 
-//define stringify function
-#define xstr(a) str(a)
-#define str(a) #a
-
 extern RemoteDebug Debug;
 
 class WebUI {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,7 +115,7 @@ void startWifiManagerCallback() {
 }
 
 void configChangeCallbackString(const char* name, String value) {
-  debugD("%s: %s", name, value);
+  debugD("%s: %s", name, value.c_str());
   if (strcmp(name, "MqttServer") == 0) updateMqtt = true;
   else if (strcmp(name, "MqttPort") == 0) updateMqtt = true;
   else if (strcmp(name, "MqttUsername") == 0) updateMqtt = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -129,7 +129,7 @@ void configChangeCallbackString(const char* name, String value) {
 
 void configChangeCallbackInt(const char* name, int value) {
   debugD("%s: %i", name, value);
-  if (strcmp(name, "UpdateFrequency") == 0) si.setUpdateFrequency(value);
+  if (strcmp(name, "spaPollFrequency") == 0) si.setPollFrequency(value);
 }
 
 void mqttHaAutoDiscovery() {
@@ -603,7 +603,7 @@ void setup() {
 
   ui.begin();
   ui.setWifiManagerCallback(startWifiManagerCallback);
-  si.setUpdateFrequency(config.UpdateFrequency.getValue());
+  si.setPollFrequency(config.spaPollFrequency.getValue());
 
   config.setCallback(configChangeCallbackString);
   config.setCallback(configChangeCallbackInt);


### PR DESCRIPTION
Two main changes:
1. Moved settings to Preferences - this is needed ahead of moving the WebUI to flash memory
2. Add the ability for the ESP to check for updates.

The update check will fail if the device doesn't have internet access. You can't disable this feature just yet, as I didn't want to make changes to the WebUI until we move it to flash memory.

If we aren't ready to implement the firmware updates, it would be good to rollout the Preferences commit, so that we can get people onto using Preferences in prep for the new WebUI.