### PR TITLE
Change Config to use Preferences

### DIFF
--- a/lib/Config/Config.h
+++ b/lib/Config/Config.h
@@ -1,6 +1,7 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#include <Preferences.h>
 #include <Arduino.h>
 #include <ArduinoJson.h>
 #include <RemoteDebug.h>
@@ -77,15 +78,18 @@ public:
     // Constructor
     Config();
 
-    // File operations
-    bool readConfigFile();
-    void writeConfigFile();
+    bool readConfig();              // Read configuration from Preferences or file
+    void writeConfig();             // Write configuration to Preferences
 
     // Set callback for all Setting instances
     template <typename T>
     void setCallback(void (*callback)(const char*, T)) {
         Setting<T>::setCallback(callback);
     }
+private:
+    bool readConfigFile();          // Read configuration from file
+    void writeConfigFile();         // Write configuration to file
+
 };
 
 #endif // CONFIG_H

--- a/lib/WebUI/WebUI.cpp
+++ b/lib/WebUI/WebUI.cpp
@@ -106,7 +106,7 @@ void WebUI::begin() {
         if (server->hasArg("mqttUsername")) _config->MqttUsername.setValue(server->arg("mqttUsername"));
         if (server->hasArg("mqttPassword")) _config->MqttPassword.setValue(server->arg("mqttPassword"));
         if (server->hasArg("updateFrequency")) _config->UpdateFrequency.setValue(server->arg("updateFrequency").toInt());
-        _config->writeConfigFile();
+        _config->writeConfig();
         server->sendHeader("Connection", "close");
         server->send(200, "text/plain", "Updated");
     });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,7 +92,7 @@ void startWiFiManager(){
     config.MqttUsername.setValue(String(custom_mqtt_username.getValue()));
     config.MqttPassword.setValue(String(custom_mqtt_password.getValue()));
 
-    config.writeConfigFile();
+    config.writeConfig();
   }
 }
 
@@ -565,7 +565,7 @@ void setup() {
     LittleFS.begin();
   }
 
-  if (!config.readConfigFile()) {
+  if (!config.readConfig()) {
     debugW("Failed to open config.json, starting Wi-Fi Manager");
     startWiFiManager();
   }


### PR DESCRIPTION
This update moves the config from a json file to Preferences. If there are Preferences, these take precedence. If there are no Preferences, and config file exists, then it will load the json config, and write it to Preferences. This ensures the configuration is automatically migrated.

Note: I haven't tested this with the Wi-Fi Manager yet, but I see no reason for it not to work.