### PR TITLE
New web UI

### DIFF
--- a/lib/WebUI/WebUI.h
+++ b/lib/WebUI/WebUI.h
@@ -17,9 +17,16 @@ class WebUI {
     public:
         WebUI(SpaInterface *spa, Config *config, MQTTClientWrapper *mqttClient);
 
+        /// @brief Set the function to be called to start Wi-Fi Manager.
+        /// @param f
+        void setWifiManagerCallback(void (*f)()) {
+          _wifiManagerCallback = f;
+        }
         /// @brief Set the function to be called when properties have been updated.
         /// @param f
-        void setWifiManagerCallback(void (*f)());
+        void setSpaCallback(void (*f)(const String, const String)) {
+          _setSpaCallback = f;
+        }
         void begin();
         bool initialised = false;
 
@@ -29,6 +36,7 @@ class WebUI {
         Config *_config;
         MQTTClientWrapper *_mqttClient;
         void (*_wifiManagerCallback)() = nullptr;
+        void (*_setSpaCallback)(const String, const String) = nullptr;
 
         const char* getError();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -437,24 +437,6 @@ void mqttPublishStatus() {
   }
 }
 
-// I don't exactly like this, but it makes the commit smaller. Ideally we'd move mqttCallback to after setSpaProperty...
-void setSpaProperty(String property, String p);
-
-void mqttCallback(char* topic, byte* payload, unsigned int length) {
-  String t = String(topic);
-
-  String p = "";
-  for (uint x = 0; x < length; x++) {
-    p += char(*payload);
-    payload++;
-  }
-
-  debugD("MQTT subscribe received '%s' with payload '%s'",topic,p.c_str());
-
-  String property = t.substring(t.lastIndexOf("/")+1);
-  setSpaProperty(property, p);
-}
-
 void setSpaProperty(String property, String p) {
 
   debugI("Received update for %s to %s",property.c_str(),p.c_str());
@@ -538,6 +520,21 @@ void setSpaProperty(String property, String p) {
   } else {
     debugE("Unhandled property - %s",property.c_str());
   }
+}
+
+void mqttCallback(char* topic, byte* payload, unsigned int length) {
+  String t = String(topic);
+
+  String p = "";
+  for (uint x = 0; x < length; x++) {
+    p += char(*payload);
+    payload++;
+  }
+
+  debugD("MQTT subscribe received '%s' with payload '%s'",topic,p.c_str());
+
+  String property = t.substring(t.lastIndexOf("/")+1);
+  setSpaProperty(property, p);
 }
 
 String sanitizeHostname(const String& input) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,6 +54,9 @@ String mqttAvailability = "";
 String spaSerialNumber = "";
 
 bool updateMqtt = false;
+bool setSpaCallbackReady = false;
+String spaCallbackProperty;
+String spaCallbackValue;
 
 void WMsaveConfigCallback(){
   WMsaveConfig = true;
@@ -109,10 +112,18 @@ void checkButton(){
   }
 #endif
 }
+
 void startWifiManagerCallback() {
   debugD("Starting Wi-Fi Manager...");
   startWiFiManager();
   ESP.restart(); //do we need to reboot here??
+}
+
+void setSpaCallback(String property, String value) {
+  debugD("setSpaCallback: %s: %s", property.c_str(), value.c_str());
+  spaCallbackProperty = property;
+  spaCallbackValue = value;
+  setSpaCallbackReady = true;
 }
 
 void configChangeCallbackString(const char* name, String value) {
@@ -426,6 +437,8 @@ void mqttPublishStatus() {
   }
 }
 
+// I don't exactly like this, but it makes the commit smaller. Ideally we'd move mqttCallback to after setSpaProperty...
+void setSpaProperty(String property, String p);
 
 void mqttCallback(char* topic, byte* payload, unsigned int length) {
   String t = String(topic);
@@ -439,6 +452,10 @@ void mqttCallback(char* topic, byte* payload, unsigned int length) {
   debugD("MQTT subscribe received '%s' with payload '%s'",topic,p.c_str());
 
   String property = t.substring(t.lastIndexOf("/")+1);
+  setSpaProperty(property, p);
+}
+
+void setSpaProperty(String property, String p) {
 
   debugI("Received update for %s to %s",property.c_str(),p.c_str());
 
@@ -606,6 +623,7 @@ void setup() {
 
   ui.begin();
   ui.setWifiManagerCallback(startWifiManagerCallback);
+  ui.setSpaCallback(setSpaCallback);
   si.setUpdateFrequency(config.UpdateFrequency.getValue());
 
   config.setCallback(configChangeCallbackString);
@@ -630,6 +648,12 @@ void loop() {
     mqttClient.disconnect();
     mqttClient.setServer(config.MqttServer.getValue(), config.MqttPort.getValue());
     updateMqtt = false;
+  }
+
+  if (setSpaCallbackReady) {
+    debugD("Setting Spa Properties...");
+    setSpaCallbackReady = false;
+    setSpaProperty(spaCallbackProperty, spaCallbackValue);
   }
 
   if (WiFi.status() != WL_CONNECTED) {


### PR DESCRIPTION
Move setSpaTime to a task, so it can run synchronously. 

This also generalises setting config in the web ui by using the existing in code in main.

The new webui class ESPAsyncWebServer seems to run code asynchronously. By using a callback to main, we avoid this problem. This also has the benefit of enabling all settings to be configured in the webui without code duplication.