### PR TITLE
Update readStatus() + Add support for V2 controllers

### DIFF
--- a/lib/SpaInterface/SpaInterface.h
+++ b/lib/SpaInterface/SpaInterface.h
@@ -9,6 +9,7 @@
 
 extern RemoteDebug Debug;
 #define FAILEDREADFREQUENCY 1000 //(ms) Frequency to retry on a failed read of the status registers.
+#define V2FIRMWARE_STRING "SW V2" // String to identify V2 firmware
 
 class SpaInterface : public SpaProperties {
     private:
@@ -17,6 +18,7 @@ class SpaInterface : public SpaProperties {
         int _updateFrequency = 60;
 
         /// @brief Number of fields that we can expect to read.
+        static const int statusResponseV2MinFields = 253;
         static const int statusResponseMinFields = 275;
         static const int statusResponseMaxFields = 300;
 
@@ -42,7 +44,7 @@ class SpaInterface : public SpaProperties {
           25, //R3
           23, //R4
           22, //R5
-          27, //R6
+          23, //R6
           30, //R7
           12, //R9
           12, //RA


### PR DESCRIPTION
Replace port.readUntil with modified code based on the source code from port.readUntil.

The modified code enables us to detect new lines and colons that form part of a field. This makes the code more efficient and enables us to support V2 controllers more easily.

fixes issue #104