### PR TITLE
soft AP updates

### DIFF
--- a/data/www/espa.js
+++ b/data/www/espa.js
@@ -190,11 +190,13 @@ function loadConfig() {
         .then(response => response.json())
         .then(data => {
             document.getElementById('spaName').value = data.spaName;
+            document.getElementById('softAPPassword').value = data.softAPPassword;
+            document.getElementById('softAPAlwaysOn').checked = data.softAPAlwaysOn
             document.getElementById('mqttServer').value = data.mqttServer;
             document.getElementById('mqttPort').value = data.mqttPort;
             document.getElementById('mqttUsername').value = data.mqttUsername;
             document.getElementById('mqttPassword').value = data.mqttPassword;
-            document.getElementById('updateFrequency').value = data.updateFrequency;
+            document.getElementById('spaPollFrequency').value = data.spaPollFrequency;
 
             // Enable form fields and save button
             $('#config_form input').prop('disabled', false);

--- a/data/www/index.htm
+++ b/data/www/index.htm
@@ -194,8 +194,16 @@
           </div>
           <form id="config_form" action='#' method='POST'>
             <div class="mb-3">
-              <label for="spaName">Spa Name</label>
+              <label for="spaName">Spa Name (also used for AP SSID)</label>
               <input type='text' class="form-control" name='spaName' id='spaName'>
+            </div>
+            <div class="mb-3">
+              <label for="softAPPassword">Soft AP Password</label>
+              <input type='text' class="form-control" name='softAPPassword' id='softAPPassword'>
+            </div>
+            <div class="mb-3">
+              <label for="softAPAlwaysOn">AP Always On</label>
+              <input type='checkbox' class="form-check-input" name='softAPAlwaysOn' id='softAPAlwaysOn'>
             </div>
             <div class="mb-3">
               <label for="mqttServer">MQTT Server</label>
@@ -214,8 +222,8 @@
               <input type='text' class="form-control" name='mqttPassword' id='mqttPassword'>
             </div>
             <div class="mb-3">
-              <label for="updateFrequency">Poll Frequency (seconds)</label>
-              <input type='number' class="form-control" name='updateFrequency' id='updateFrequency' step="1" min="10" max="300">
+              <label for="spaPollFrequency">Spa Poll Frequency (seconds)</label>
+              <input type='number' class="form-control" name='spaPollFrequency' id='spaPollFrequency' step="1" min="10" max="300">
             </div>
           </form>
         </div>

--- a/get_version.py
+++ b/get_version.py
@@ -33,6 +33,11 @@ def get_git_version():
 
     return version
 
+build_info = get_git_version()
 # Append the version to build flags
-env.Append(CPPDEFINES=[("BUILD_INFO", f'"{get_git_version()}"')])
+env.Append(CPPDEFINES=[("BUILD_INFO", f'"{build_info}"')])
 env.Append(CPPDEFINES=[("PIOENV", f'"{env["PIOENV"]}"')])
+
+# Output the values to the console
+print(f"BUILD_INFO: {build_info}")
+print(f"PIOENV: {env['PIOENV']}")

--- a/lib/Config/Config.cpp
+++ b/lib/Config/Config.cpp
@@ -22,7 +22,9 @@ bool Config::readConfig() {
     MqttUsername.setValue(preferences.getString("MqttUsername", ""));
     MqttPassword.setValue(preferences.getString("MqttPassword", ""));
     SpaName.setValue(preferences.getString("SpaName", "eSpa"));
-    UpdateFrequency.setValue(preferences.getInt("spaPollFreq", 60));
+    SpaPollFrequency.setValue(preferences.getInt("spaPollFreq", 60));
+    SoftAPAlwaysOn.setValue(preferences.getBool("SoftAPAlwaysOn", true));
+    SoftAPPassword.setValue(preferences.getString("SoftAPPassword", "eSPA-Password"));
 
     preferences.end();
     return true;
@@ -41,7 +43,9 @@ void Config::writeConfig() {
     preferences.putString("MqttUsername", MqttUsername.getValue());
     preferences.putString("MqttPassword", MqttPassword.getValue());
     preferences.putString("SpaName", SpaName.getValue());
-    preferences.putInt("spaPollFreq", UpdateFrequency.getValue());
+    preferences.putInt("spaPollFreq", SpaPollFrequency.getValue());
+    preferences.putBool("SoftAPAlwaysOn", SoftAPAlwaysOn.getValue());
+    preferences.putString("SoftAPPassword", SoftAPPassword.getValue());
     preferences.end();
   } else {
     debugE("Failed to open Preferences for writing");

--- a/lib/Config/Config.h
+++ b/lib/Config/Config.h
@@ -69,7 +69,9 @@ public:
     Setting<String> MqttUsername = Setting<String>("MqttUsername");
     Setting<String> MqttPassword = Setting<String>("MqttPassword");
     Setting<String> SpaName = Setting<String>("SpaName", "eSpa");
-    Setting<int> UpdateFrequency = Setting<int>("UpdateFrequency", 60, 10, 300);
+    Setting<int> SpaPollFrequency = Setting<int>("SpaPollFrequency", 60, 10, 300);
+    Setting<bool> SoftAPAlwaysOn = Setting<bool>("SoftAPAlwaysOn", true);
+    Setting<String> SoftAPPassword = Setting<String>("SoftAPPassword", "eSPA-Password");
 };
 
 class Config : public ControllerConfig {

--- a/lib/SpaInterface/SpaInterface.cpp
+++ b/lib/SpaInterface/SpaInterface.cpp
@@ -12,7 +12,7 @@ SpaInterface::SpaInterface() : port(SPA_SERIAL) {
 SpaInterface::~SpaInterface() {}
 
 
-void SpaInterface::setUpdateFrequency(int updateFrequency) {
+void SpaInterface::setSpaPollFrequency(int updateFrequency) {
     _updateFrequency = updateFrequency;
 }
 

--- a/lib/SpaInterface/SpaInterface.h
+++ b/lib/SpaInterface/SpaInterface.h
@@ -115,8 +115,8 @@ class SpaInterface : public SpaProperties {
         ~SpaInterface();
 
         /// @brief configure how often the spa is polled in seconds.
-        /// @param updateFrequency
-        void setUpdateFrequency(int updateFrequency);
+        /// @param SpaPollFrequency
+        void setSpaPollFrequency(int updateFrequency);
 
         /// @brief Complete RF command response in a single string
         Property<String> statusResponse;

--- a/lib/WebUI/WebUI.cpp
+++ b/lib/WebUI/WebUI.cpp
@@ -84,11 +84,14 @@ void WebUI::begin() {
     server.on("/config", HTTP_POST, [this](AsyncWebServerRequest *request) {
         debugD("uri: %s", request->url().c_str());
         if (request->hasParam("spaName", true)) _config->SpaName.setValue(request->getParam("spaName", true)->value());
+        if (request->hasParam("softAPAlwaysOn", true)) _config->SoftAPAlwaysOn.setValue(true);
+        else _config->SoftAPAlwaysOn.setValue(false); // Default to false if not provided
+        if (request->hasParam("softAPPassword", true)) _config->SoftAPPassword.setValue(request->getParam("softAPPassword", true)->value());
         if (request->hasParam("mqttServer", true)) _config->MqttServer.setValue(request->getParam("mqttServer", true)->value());
         if (request->hasParam("mqttPort", true)) _config->MqttPort.setValue(request->getParam("mqttPort", true)->value().toInt());
         if (request->hasParam("mqttUsername", true)) _config->MqttUsername.setValue(request->getParam("mqttUsername", true)->value());
         if (request->hasParam("mqttPassword", true)) _config->MqttPassword.setValue(request->getParam("mqttPassword", true)->value());
-        if (request->hasParam("updateFrequency", true)) _config->UpdateFrequency.setValue(request->getParam("updateFrequency", true)->value().toInt());
+        if (request->hasParam("spaPollFrequency", true)) _config->SpaPollFrequency.setValue(request->getParam("spaPollFrequency", true)->value().toInt());
         _config->writeConfig();
         AsyncWebServerResponse *response = request->beginResponse(200, "text/plain", "Updated");
         response->addHeader("Connection", "close");
@@ -99,11 +102,13 @@ void WebUI::begin() {
         debugD("uri: %s", request->url().c_str());
         String configJson = "{";
         configJson += "\"spaName\":\"" + _config->SpaName.getValue() + "\",";
+        configJson += "\"softAPAlwaysOn\":" + String(_config->SoftAPAlwaysOn.getValue() ? "true" : "false") + ",";
+        configJson += "\"softAPPassword\":\"" + _config->SoftAPPassword.getValue() + "\",";
         configJson += "\"mqttServer\":\"" + _config->MqttServer.getValue() + "\",";
         configJson += "\"mqttPort\":\"" + String(_config->MqttPort.getValue()) + "\",";
         configJson += "\"mqttUsername\":\"" + _config->MqttUsername.getValue() + "\",";
         configJson += "\"mqttPassword\":\"" + _config->MqttPassword.getValue() + "\",";
-        configJson += "\"updateFrequency\":" + String(_config->UpdateFrequency.getValue());
+        configJson += "\"spaPollFrequency\":" + String(_config->SpaPollFrequency.getValue());
         configJson += "}";
         AsyncWebServerResponse *response = request->beginResponse(200, "application/json", configJson);
         response->addHeader("Connection", "close");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,9 +45,7 @@ ulong bootTime = millis();
 ulong statusLastPublish = millis();
 bool delayedStart = true; // Delay spa connection for 10sec after boot to allow for external debugging if required.
 bool autoDiscoveryPublished = false;
-bool softAPAlwaysOn = false; // If true, the AP will always be on, even if Wi-Fi is connected.
 bool wifiRestoredFlag = true; // Flag to indicate if Wi-Fi has been restored after a disconnect.
-String softAPPassword = "eSPA-Password"; // Password for the soft AP.
 
 String mqttBase = "";
 String mqttStatusTopic = "";
@@ -60,6 +58,8 @@ String spaSerialNumber = "";
 /// @brief Flag to indicate that the mqtt configuration has changed and therefore the MQTT
 /// client needs to be restarted.
 bool updateMqtt = false;
+/// @brief Flag to indicate that the Wi-Fi configuration has changed and therefore the Wi-Fi
+bool updateSoftAP = false;
 bool setSpaCallbackReady = false;
 String spaCallbackProperty;
 String spaCallbackValue;
@@ -139,11 +139,17 @@ void configChangeCallbackString(const char* name, String value) {
   else if (strcmp(name, "MqttPassword") == 0) updateMqtt = true;
   else if (strcmp(name, "SpaName") == 0) { } //TODO - Changing the SpaName currently requires the user to:
                                   // delete the entities in MQTT then reboot the ESP
+  else if (strcmp(name, "SoftAPPassword") == 0) updateSoftAP = true;
 }
 
 void configChangeCallbackInt(const char* name, int value) {
   debugD("%s: %i", name, value);
-  if (strcmp(name, "UpdateFrequency") == 0) si.setUpdateFrequency(value);
+  if (strcmp(name, "SpaPollFrequency") == 0) si.setSpaPollFrequency(value);
+}
+
+void configChangeCallbackBool(const char* name, bool value) {
+  debugD("%s: %s", name, value ? "true" : "false");
+  if (strcmp(name, "SoftAPAlwaysOn") == 0) updateSoftAP = true;
 }
 
 void mqttHaAutoDiscovery() {
@@ -577,7 +583,7 @@ void wifiRestored() {
   debugI("Wi-Fi connection restored");
   wifiRestoredFlag = true;
 
-  if (!softAPAlwaysOn) {
+  if (!config.SoftAPAlwaysOn.getValue()) {
     WiFi.softAPdisconnect(true); // Disable AP mode if reconnected
     WiFi.mode(WIFI_STA);
   }
@@ -620,9 +626,9 @@ void setup() {
   blinker.setState(STATE_WIFI_NOT_CONNECTED);
   WiFi.setHostname(sanitizeHostname(config.SpaName.getValue()).c_str());
 
-  if (softAPAlwaysOn) {
+  if (config.SoftAPAlwaysOn.getValue()) {
     WiFi.mode(WIFI_AP_STA);
-    WiFi.softAP(WiFi.getHostname(), softAPPassword.c_str());
+    WiFi.softAP(WiFi.getHostname(), config.SoftAPPassword.getValue().c_str());
   } else {
     WiFi.mode(WIFI_STA);
   }
@@ -640,9 +646,9 @@ void setup() {
     debugA("mDNS responder started");
   } else {
     debugW("Failed to connect to Wi-Fi, starting AP mode");
-    if (!softAPAlwaysOn) {
+    if (!config.SoftAPAlwaysOn.getValue()) {
       WiFi.mode(WIFI_AP_STA);
-      WiFi.softAP(WiFi.getHostname(), softAPPassword.c_str());
+      WiFi.softAP(WiFi.getHostname(), config.SoftAPPassword.getValue().c_str());
     }
   }
 
@@ -660,10 +666,11 @@ void setup() {
 
   ui.setWifiManagerCallback(startWifiManagerCallback);
   ui.setSpaCallback(setSpaCallback);
-  si.setUpdateFrequency(config.UpdateFrequency.getValue());
+  si.setSpaPollFrequency(config.SpaPollFrequency.getValue());
 
   config.setCallback(configChangeCallbackString);
   config.setCallback(configChangeCallbackInt);
+  config.setCallback(configChangeCallbackBool);
 
 }
 
@@ -694,10 +701,10 @@ void loop() {
         wifiRestored();
       } else {
         debugW("Wifi reconnect failed");
-        if (WiFi.getMode() == WIFI_STA && !softAPAlwaysOn) {
+        if (WiFi.getMode() == WIFI_STA && !config.SoftAPAlwaysOn.getValue()) {
           debugW("Failed to connect to Wi-Fi, starting AP mode");
           WiFi.mode(WIFI_AP_STA);
-          WiFi.softAP(WiFi.getHostname(), softAPPassword.c_str()); // Start the AP with the hostname and password
+          WiFi.softAP(WiFi.getHostname(), config.SoftAPPassword.getValue().c_str()); // Start the AP with the hostname and password
         } else {
           debugE("Failed to connect to Wi-Fi, but already in AP mode");
         }
@@ -774,6 +781,21 @@ void loop() {
     mqttClient.disconnect();
     mqttClient.setServer(config.MqttServer.getValue(), config.MqttPort.getValue());
     updateMqtt = false;
+  }
+
+  if (updateSoftAP) {
+    debugD("Changing SoftAP settings...");
+
+    if (config.SoftAPAlwaysOn.getValue()) {
+      WiFi.mode(WIFI_AP_STA);
+      WiFi.softAP(config.SpaName.getValue().c_str(), config.SoftAPPassword.getValue().c_str());
+      debugI("Soft AP enabled");
+    } else {
+      WiFi.softAPdisconnect(true);
+      WiFi.mode(WIFI_STA);
+      debugI("Soft AP disabled");
+    }
+    updateSoftAP = false;
   }
 
   mqttClient.loop();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -613,6 +613,13 @@ void setup() {
   WiFi.begin();
   if (WiFi.waitForConnectResult() == WL_CONNECTED) {
     debugI("Connected to Wi-Fi as %s", WiFi.getHostname());
+    int totalTry = 5;
+    while (!MDNS.begin(WiFi.getHostname()) && totalTry > 0) {
+      debugW(".");
+      delay(1000);
+      totalTry--;
+    }
+    debugA("mDNS responder started");
   } else {
     debugW("Failed to connect to Wi-Fi, starting AP mode");
     if (!softAPAlwaysOn) {


### PR DESCRIPTION
Adds:
* Ability to set the soft AP password in the web ui
* Ability to disable always on soft AP - when always on is disabled, the soft AP turns on only if wifi goes down.
* Fix mDNS not starting on boot
* Renamed config setting for spa poll frequency for clarity
* Added logging to build python script